### PR TITLE
Remove emergent references

### DIFF
--- a/.emergent/emergent.yml
+++ b/.emergent/emergent.yml
@@ -1,3 +1,0 @@
-{
-  "env_image_name": "fastapi_react_mongo_base_image_cloud_arm:release-04072025-2"
-}

--- a/backend/.env
+++ b/backend/.env
@@ -1,3 +1,3 @@
 MONGO_URL="mongodb://localhost:27017"
 DB_NAME="test_database"
-STRIPE_API_KEY="sk_test_emergent"
+STRIPE_API_KEY="sk_test"

--- a/backend_test.py
+++ b/backend_test.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Dict, List, Any
 
 # Backend URL from frontend/.env
-BACKEND_URL = "https://55dcae2e-605d-4eee-8e34-b0c44591c936.preview.emergentagent.com/api"
+BACKEND_URL = "http://localhost:8000/api"
 
 class TeaScrapingAPITester:
     def __init__(self, base_url: str):

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-REACT_APP_BACKEND_URL=https://55dcae2e-605d-4eee-8e34-b0c44591c936.preview.emergentagent.com
+REACT_APP_BACKEND_URL=http://localhost:8000
 WDS_SOCKET_PORT=443

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
-        <meta name="description" content="A product of emergent.sh" />
+        <meta name="description" content="Chinese Tea Scraper" />
         <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -18,7 +18,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-        <title>Emergent | Fullstack App</title>
+        <title>Fullstack App</title>
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>
@@ -33,53 +33,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-        <a
-            id="emergent-badge"
-            target="_blank"
-            href="https://app.emergent.sh/?utm_source=emergent-badge"
-            style="
-                display: flex !important;
-                align-items: center !important;
-                position: fixed !important;
-                bottom: 20px;
-                right: 20px;
-                text-decoration: none;
-                padding: 6px 10px;
-                font-family: -apple-system, BlinkMacSystemFont,
-                    &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, Cantarell,
-                    &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;,
-                    sans-serif !important;
-                font-size: 12px !important;
-                z-index: 9999 !important;
-                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
-                border-radius: 8px !important;
-                background-color: #ffffff !important;
-                border: 1px solid rgba(255, 255, 255, 0.25) !important;
-            "
-        >
-            <div
-                style="display: flex; flex-direction: row; align-items: center"
-            >
-                <img
-                    style="width: 20px; height: 20px; margin-right: 8px"
-                    src="https://avatars.githubusercontent.com/in/1201222?s=120&u=2686cf91179bbafbc7a71bfbc43004cf9ae1acea&v=4"
-                />
-                <p
-                    style="
-                        color: #000000;
-                        font-family: -apple-system, BlinkMacSystemFont,
-                            &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu,
-                            Cantarell, &quot;Open Sans&quot;,
-                            &quot;Helvetica Neue&quot;, sans-serif !important;
-                        font-size: 12px !important;
-                        align-items: center;
-                        margin-bottom: 0;
-                    "
-                >
-                    Made with Emergent
-                </p>
-            </div>
-        </a>
         <script>
             !(function (t, e) {
                 var o, n, p, r;

--- a/scraping_test.py
+++ b/scraping_test.py
@@ -7,7 +7,7 @@ import requests
 import time
 import json
 
-BACKEND_URL = "https://55dcae2e-605d-4eee-8e34-b0c44591c936.preview.emergentagent.com/api"
+BACKEND_URL = "http://localhost:8000/api"
 
 def test_scraping_workflow():
     print("Testing complete scraping workflow...")


### PR DESCRIPTION
## Summary
- drop `.emergent` config
- replace emergent backend URLs in tests and env files with localhost
- strip emergent branding from the frontend template

## Testing
- `pytest -q` *(fails: ConnectionRefusedError - backend not running)*

------
https://chatgpt.com/codex/tasks/task_e_6870e16058008330b8e5bf0169265ebf