### PR TITLE
Split App.js into dedicated pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -70,27 +70,29 @@ export default function App() {
   const [searchTerm, setSearchTerm] = useState("puer");
   const [categories, setCategories] = useState([]);
 
-  // URL init guard: не пишем в URL, пока не распарсили его
+  // guard: пишем в URL только после первичной инициализации
   const [didInitFromUrl, setDidInitFromUrl] = useState(false);
 
-  // --- deep-linking: парсинг URL -> state (только tab)
+  // ---- URL -> state (только tab)
   const parseUrlToState = useCallback(() => {
     const sp = new URLSearchParams(window.location.search);
     const tab = sp.get("tab");
     if (tab) setActiveTab(tab);
   }, []);
 
-  // --- deep-linking: state -> URL (только tab)
+  // ---- state -> URL: сохраняем существующие query-параметры (включая фильтры products),
+  // просто обновляем tab. Это и обеспечивает сохранность фильтров при уходе/возврате.
   const writeStateToUrl = useCallback(() => {
-    const sp = new URLSearchParams(window.location.search);
+    if (!didInitFromUrl) return;
+    const sp = new URLSearchParams(window.location.search); // <— сохраняем всё
     sp.set("tab", activeTab);
     const nextUrl = `${window.location.pathname}?${sp.toString()}`;
     if (nextUrl !== `${window.location.pathname}${window.location.search}`) {
       window.history.replaceState(null, "", nextUrl);
     }
-  }, [activeTab]);
+  }, [activeTab, didInitFromUrl]);
 
-  // --- API calls unrelated to ProductsPage ---
+  // --- API (не связанные с ProductsPage) ---
   const fetchStats = useCallback(async () => {
     const res = await api.get("/stats");
     setStats(res.data || {});
@@ -107,9 +109,10 @@ export default function App() {
 
   const fetchCategories = useCallback(async () => {
     const res = await api.get("/categories");
-    setCategories(res.data?.categories || []); // на будущее
+    setCategories(res.data?.categories || []);
   }, []);
 
+  // Открыть продукты по задаче: кладём продукты-параметры в URL
   const openProductsForTask = useCallback((taskId, scope = "task") => {
     const sp = new URLSearchParams(window.location.search);
     sp.set("tab", "products");
@@ -126,12 +129,12 @@ export default function App() {
     setActiveTab("tasks");
   }, []);
 
-  // Писать в URL только после инициализации из URL
+  // писать tab в URL при каждом изменении активной вкладки
   useEffect(() => {
-    if (didInitFromUrl) writeStateToUrl();
-  }, [writeStateToUrl, didInitFromUrl]);
+    writeStateToUrl();
+  }, [writeStateToUrl]);
 
-  // Initial load
+  // первичная загрузка
   useEffect(() => {
     parseUrlToState();
     setDidInitFromUrl(true);
@@ -224,7 +227,8 @@ export default function App() {
                   activeTab === tab.id
                     ? "border-blue-500 text-blue-600"
                     : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-                }`}>
+                }`}
+              >
                 <span>{tab.icon}</span>
                 <span>{tab.label}</span>
               </button>
@@ -299,7 +303,8 @@ export default function App() {
                 <button
                   onClick={startScraping}
                   disabled={loading}
-                  className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition-colors">
+                  className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition-colors"
+                >
                   {loading ? "🔄 Starting..." : "🚀 Start"}
                 </button>
               </div>
@@ -311,7 +316,8 @@ export default function App() {
                     <button
                       key={term}
                       onClick={() => setSearchTerm(term)}
-                      className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm hover:bg-blue-200 transition-colors">
+                      className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm hover:bg-blue-200 transition-colors"
+                    >
                       {term}
                     </button>
                   ))}
@@ -350,7 +356,8 @@ export default function App() {
                 <h3 className="text-lg font-semibold">Task history</h3>
                 <button
                   onClick={() => fetchTasks().catch(() => {})}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                >
                   🔄 Refresh
                 </button>
               </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,78 +1,26 @@
 // App.js
 import React, { useCallback, useEffect, useState } from "react";
 import axios from "axios";
-import PropTypes from "prop-types";
 import "./App.css";
-import TasksPage from "./components/TasksPage";
-import ProductsPage from "./components/ProductsPage";
 
+// страницы
+import DashboardPage from "./components/DashboardPage";
+import ScrapingPage from "./components/ScrapingPage";
+import ProductsPage from "./components/ProductsPage";
+import TasksPage from "./components/TasksPage";
+
+// --- API instance ---
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || "";
 const API = `${BACKEND_URL}/api/v1`;
 const api = axios.create({ baseURL: API });
 
-function formatDate(input) {
-  if (!input) return "N/A";
-  const d = new Date(input);
-  if (Number.isNaN(d.getTime())) return "N/A";
-  return d.toLocaleString("en-GB");
-}
-
-function StatusBadge({ status }) {
-  const cls =
-    status === "finished"
-      ? "bg-green-100 text-green-800"
-      : status === "running"
-      ? "bg-blue-100 text-blue-800"
-      : status === "failed"
-      ? "bg-red-100 text-red-800"
-      : status === "pending"
-      ? "bg-yellow-100 text-yellow-800"
-      : "bg-gray-100 text-gray-800";
-  return <span className={`px-2 py-1 rounded-full text-xs font-medium ${cls}`}>{status}</span>;
-}
-StatusBadge.propTypes = { status: PropTypes.string };
-
-function StatCard({ title, value, subtitle, tone = "blue" }) {
-  const toneMap = {
-    blue: "border-blue-500",
-    red: "border-red-500",
-    green: "border-green-500",
-    purple: "border-purple-500",
-    yellow: "border-yellow-500",
-  };
-  const border = toneMap[tone] || toneMap.blue;
-  return (
-    <div className={`bg-white rounded-lg shadow-md p-6 border-l-4 ${border}`}>
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-medium text-gray-600">{title}</p>
-          <p className="text-2xl font-bold text-gray-900">{value}</p>
-          {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
-        </div>
-        <div className="text-3xl">📊</div>
-      </div>
-    </div>
-  );
-}
-StatCard.propTypes = {
-  title: PropTypes.string.isRequired,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  subtitle: PropTypes.string,
-  tone: PropTypes.oneOf(["blue", "red", "green", "purple", "yellow"]),
-};
-
 export default function App() {
   const [activeTab, setActiveTab] = useState("dashboard");
-  const [tasks, setTasks] = useState([]);
-  const [stats, setStats] = useState({});
-  const [loading, setLoading] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("puer");
-  const [categories, setCategories] = useState([]);
 
-  // Храним последний набор фильтров Products (переживает переключение вкладок)
+  // Храним последний запрос фильтров для Products — переживает переключение вкладок
   const [lastProductsQuery, setLastProductsQuery] = useState(null);
 
-  // Пишем в URL только после первичной инициализации
+  // Пишем в URL только после первичной инициализации из URL
   const [didInitFromUrl, setDidInitFromUrl] = useState(false);
 
   // ---- URL -> state (читаем только tab)
@@ -84,10 +32,11 @@ export default function App() {
   }, []);
 
   // ---- state -> URL
-  // Для вкладки products: оставляем product-параметры нетронутыми (ими управляет ProductsPage), но гарантируем tab=products.
-  // Для остальных вкладок: в URL только ?tab=...
+  // Для вкладки products: сохраняем существующие product-параметры (ими управляет ProductsPage), но гарантируем tab=products.
+  // Для остальных вкладок: в URL оставляем ТОЛЬКО ?tab=...
   useEffect(() => {
     if (!didInitFromUrl) return;
+
     const cur = `${window.location.pathname}${window.location.search}`;
     let next = cur;
 
@@ -104,17 +53,8 @@ export default function App() {
     if (next !== cur) window.history.replaceState(null, "", next);
   }, [activeTab, didInitFromUrl]);
 
-  // Данные для дашборда/истории задач
-  useEffect(() => {
-    api.get("/stats").then((r) => setStats(r.data || {})).catch(() => {});
-    api
-      .get(`/tasks?limit=200`)
-      .then((r) => setTasks(r.data?.items || r.data || []))
-      .catch(() => {});
-    api.get("/categories").then((r) => setCategories(r.data?.categories || [])).catch(() => {});
-  }, []);
-
-  // Переход из задач во вкладку products с предустановкой фильтров
+  // Deep-link из задач во вкладку products — сразу кладём ключевые product-параметры.
+  // Остальные (limit/sort/q/filters) восстановит ProductsPage из lastProductsQuery или URL.
   const openProductsForTask = useCallback((taskId, scope = "task") => {
     setLastProductsQuery((prev) => ({
       ...(prev || {}),
@@ -126,22 +66,7 @@ export default function App() {
     setActiveTab("products");
   }, []);
 
-  const startScraping = useCallback(async () => {
-    const term = String(searchTerm || "").trim();
-    if (!term) return;
-    setLoading(true);
-    try {
-      const res = await api.post(`/scrape/start?search_term=${encodeURIComponent(term)}`);
-      window.alert(`Scraping started. Task ID: ${res.data?.task_id || "N/A"}`);
-      api.get(`/tasks?limit=200`).then((r) => setTasks(r.data?.items || r.data || [])).catch(() => {});
-      api.get("/stats").then((r) => setStats(r.data || {})).catch(() => {});
-    } catch {
-      window.alert("Failed to start scraping.");
-    } finally {
-      setLoading(false);
-    }
-  }, [searchTerm]);
-
+  // Экспорт CSV из шапки
   const exportCSV = useCallback(async () => {
     const res = await api.get("/export/csv");
     const rows = Array.isArray(res.data?.data) ? res.data.data : [];
@@ -210,8 +135,7 @@ export default function App() {
                   activeTab === tab.id
                     ? "border-blue-500 text-blue-600"
                     : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-                }`}
-              >
+                }`}>
                 <span>{tab.icon}</span>
                 <span>{tab.label}</span>
               </button>
@@ -221,121 +145,16 @@ export default function App() {
       </nav>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {activeTab === "dashboard" && (
-          <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-              <StatCard title="Products total" value={stats.total_products || 0} subtitle="In database" />
-              <StatCard title="Active tasks" value={stats.running_tasks || 0} subtitle="In progress" />
-              <StatCard title="Finished tasks" value={stats.finished_tasks || 0} subtitle="Succeeded" />
-              <StatCard title="Error rate" value={`${Number(stats.error_rate || 0).toFixed(1)}%`} subtitle="All time" tone="red" />
-            </div>
+        {activeTab === "dashboard" && <DashboardPage api={api} onOpenProducts={openProductsForTask} />}
 
-            {stats.total_products === 0 && (stats.total_tasks || 0) > 0 && (
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
-                <div className="flex items-start">
-                  <div className="text-yellow-600 text-2xl mr-4">⚠️</div>
-                  <div>
-                    <h3 className="text-lg font-semibold text-yellow-800 mb-2">Potential geo-blocking</h3>
-                    <p className="text-yellow-700 mb-4">All scraping tasks finish with 0 products. Possible reasons:</p>
-                    <ul className="text-yellow-700 space-y-1 mb-4 list-disc list-inside">
-                      <li>Geo restrictions for non-Russian IPs</li>
-                      <li>Missing tokens or region configuration</li>
-                      <li>Cookie ozon_regions is not set</li>
-                    </ul>
-                    <div className="bg-yellow-100 p-3 rounded-lg text-sm text-yellow-800">
-                      Use Russian proxies and set a valid Ozon region cookie.
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            <div className="bg-white rounded-lg shadow-md p-6">
-              <h3 className="text-lg font-semibold mb-4">Recent tasks</h3>
-              <div className="space-y-3">
-                {(tasks || []).slice(0, 5).map((task) => (
-                  <div key={task.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                    <div>
-                      <p className="font-medium">{task.search_term}</p>
-                      <p className="text-sm text-gray-500">{formatDate(task.created_at)}</p>
-                      {task.error_message && <p className="text-sm text-red-600 mt-1">{task.error_message}</p>}
-                    </div>
-                    <div className="flex items-center space-x-3">
-                      <span className="text-sm text-gray-600">{task.scraped_products || 0} items</span>
-                      <StatusBadge status={task.status} />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {activeTab === "scraping" && (
-          <div className="space-y-6">
-            <div className="bg-white rounded-lg shadow-md p-6">
-              <h3 className="text-lg font-semibold mb-4">Start scraping</h3>
-              <div className="flex items-center space-x-4">
-                <input
-                  type="text"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="Enter a search query (e.g. 'puer')"
-                  className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-                <button
-                  onClick={startScraping}
-                  disabled={loading}
-                  className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition-colors"
-                >
-                  {loading ? "🔄 Starting..." : "🚀 Start"}
-                </button>
-              </div>
-
-              <div className="mt-4 p-4 bg-blue-50 rounded-lg">
-                <h4 className="font-medium text-blue-900 mb-2">Suggested queries</h4>
-                <div className="flex flex-wrap gap-2">
-                  {["puer", "sheng puer", "shu puer", "oolong", "chinese tea", "green tea"].map((term) => (
-                    <button
-                      key={term}
-                      onClick={() => setSearchTerm(term)}
-                      className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm hover:bg-blue-200 transition-colors"
-                    >
-                      {term}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            <div className="bg-white rounded-lg shadow-md p-6">
-              <h3 className="text-lg font-semibold mb-4">Scraping statistics</h3>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="p-4 bg-green-50 rounded-lg">
-                  <div className="text-green-600 text-sm font-medium">Captchas solved</div>
-                  <div className="text-2xl font-bold text-green-900">{stats.captcha_solves || 0}</div>
-                </div>
-                <div className="p-4 bg-blue-50 rounded-lg">
-                  <div className="text-blue-600 text-sm font-medium">Total tasks</div>
-                  <div className="text-2xl font-bold text-blue-900">{stats.total_tasks || 0}</div>
-                </div>
-                <div className="p-4 bg-purple-50 rounded-lg">
-                  <div className="text-purple-600 text-sm font-medium">Success rate</div>
-                  <div className="text-2xl font-bold text-purple-900">
-                    {stats.total_tasks > 0 ? ((Number(stats.finished_tasks || 0) / Number(stats.total_tasks || 1)) * 100).toFixed(1) : 0}%
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        {activeTab === "scraping" && <ScrapingPage api={api} />}
 
         {activeTab === "products" && (
           <ProductsPage
             api={api}
-            // сюда придут сохранённые фильтры при повторном заходе
+            // сюда попадут сохранённые фильтры при повторном заходе
             initialQuery={lastProductsQuery || undefined}
-            // ProductsPage будет вызывать это при любом изменении фильтров/страницы/сортировки
+            // ProductsPage будет звать это при любом изменении фильтров/страницы/сортировки
             onPersist={setLastProductsQuery}
           />
         )}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,43 +3,15 @@ import axios from "axios";
 import PropTypes from "prop-types";
 import "./App.css";
 import ProductModal from "./components/ProductModal";
+import ProductCard from "./components/ProductCard";
 import TaskItem from "./components/TaskItem";
 import ProductsFilter from "./components/ProductsFilter";
+import Pagination from "./components/Pagination";
 import { RxUpdate } from "react-icons/rx";
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || "";
 const API = `${BACKEND_URL}/api/v1`;
 const api = axios.create({ baseURL: API });
-
-const DateLike = PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]);
-
-const ProductPropType = PropTypes.shape({
-  id: PropTypes.string.isRequired,
-  title: PropTypes.string,
-  name: PropTypes.string,
-  sku: PropTypes.string,
-  created_at: DateLike,
-  updated_at: DateLike,
-  scraped_at: DateLike,
-  cover_image: PropTypes.string,
-  description: PropTypes.shape({
-    content_blocks: PropTypes.arrayOf(
-      PropTypes.shape({
-        img: PropTypes.shape({ alt: PropTypes.string, src: PropTypes.string }),
-      }),
-    ),
-  }),
-  gallery: PropTypes.object,
-  characteristics: PropTypes.shape({
-    full: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string,
-        title: PropTypes.string,
-        values: PropTypes.arrayOf(PropTypes.string),
-      }),
-    ),
-  }),
-});
 
 function formatDate(input) {
   if (!input) return "N/A";
@@ -90,133 +62,6 @@ StatCard.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   subtitle: PropTypes.string,
   tone: PropTypes.oneOf(["blue", "red", "green", "purple", "yellow"]),
-};
-
-function pickCover(product) {
-  if (product?.cover_image) return product.cover_image;
-  const blocks = product?.description?.content_blocks || [];
-  for (const b of blocks) {
-    if (b?.img?.src) return b.img.src;
-  }
-  const g = product?.gallery;
-  if (g?.images?.length) return g.images[0];
-  return null;
-}
-
-function extractSpecs(product) {
-  const list = product?.characteristics?.full || [];
-  const byId = Object.fromEntries(list.map((x) => [x.id, x]));
-  const byTitle = Object.fromEntries(list.map((x) => [String(x.title || "").toLowerCase(), x]));
-  const pick = (keyId, keyTitle) => {
-    const item = byId[keyId] || byTitle[keyTitle];
-    return item?.values?.filter(Boolean)?.join(", ");
-  };
-  return [
-    { label: "Type", val: pick("TeaType", "вид чая") },
-    { label: "Weight, g", val: pick("Weight", "вес товара, г") },
-    { label: "Taste", val: pick("TeaTaste", "вкус") },
-    { label: "Country", val: pick("Country", "страна-изготовитель") },
-    {
-      label: "Form",
-      val: pick("VarietyTeaShape", "форма чая") || pick("Type", "тип"),
-    },
-  ].filter((x) => x.val);
-}
-
-function TeaCard({ product, onDelete, onOpen }) {
-  const img = pickCover(product);
-  const title = product.title || product.name || product.sku || "Untitled";
-  const specs = extractSpecs(product);
-  const ts = product.updated_at || product.created_at || product.scraped_at;
-
-  return (
-    <div
-      className="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow cursor-pointer relative" // cursor + relative
-      onClick={onOpen} // Открытие модалки при клике на карточку
-    >
-      {/* Крестик удаления: закрепляем сверху, выше клика по карточке */}
-      <button
-        onClick={(e) => {
-          e.stopPropagation(); // НЕ открывать модалку
-          onDelete(product.id);
-        }}
-        className="absolute top-2 right-2 z-10 text-red-500 hover:text-red-700 text-sm bg-white/90 rounded-full px-2 py-1 shadow"
-        title="Delete"
-        aria-label="Delete">
-        ❌
-      </button>
-
-      <div className="flex justify-between items-start mb-3 pr-8">
-        <h3 className="text-base font-semibold text-gray-900 line-clamp-2">{title}</h3>
-      </div>
-
-      {img ? (
-        <img src={img} alt={title} className="w-full h-44 object-cover rounded-lg mb-3" />
-      ) : (
-        <div className="w-full h-44 rounded-lg mb-3 bg-gray-100 flex items-center justify-center text-4xl">🍵</div>
-      )}
-
-      <div className="space-y-1 text-sm">
-        {specs.map((s) => (
-          <div key={s.label} className="flex justify-between">
-            <span className="text-gray-600">{s.label}:</span>
-            <span className="font-medium text-gray-900 text-right">{s.val}</span>
-          </div>
-        ))}
-        <div className="flex justify-between text-xs pt-1 text-gray-500">
-          <span>Updated:</span>
-          <span>{formatDate(ts)}</span>
-        </div>
-      </div>
-    </div>
-  );
-}
-TeaCard.propTypes = {
-  product: ProductPropType.isRequired,
-  onDelete: PropTypes.func.isRequired,
-  onOpen: PropTypes.func.isRequired, // добавили
-};
-
-function Pagination({ page, totalPages, pageSize, onPageChange, onPageSizeChange }) {
-  return (
-    <div className="flex items-center justify-between mt-6">
-      <div className="flex items-center space-x-2">
-        <button
-          onClick={() => onPageChange(Math.max(1, page - 1))}
-          disabled={page === 1}
-          className="px-3 py-1 bg-white border rounded-lg disabled:opacity-50">
-          ← Prev
-        </button>
-        <span className="text-sm text-gray-600">
-          Page <strong>{page}</strong> of <strong>{totalPages}</strong>
-        </span>
-        <button
-          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
-          disabled={page >= totalPages}
-          className="px-3 py-1 bg-white border rounded-lg disabled:opacity-50">
-          Next →
-        </button>
-      </div>
-
-      <div className="flex items-center space-x-2">
-        <span className="text-sm text-gray-600">Per page:</span>
-        <select value={pageSize} onChange={(e) => onPageSizeChange(parseInt(e.target.value, 10))} className="px-2 py-1 border rounded-lg">
-          {[12, 24, 48, 96].map((sz) => (
-            <option key={sz} value={sz}>
-              {sz}
-            </option>
-          ))}
-        </select>
-      </div>
-    </div>
-  );
-}
-Pagination.propTypes = {
-  page: PropTypes.number.isRequired,
-  totalPages: PropTypes.number.isRequired,
-  pageSize: PropTypes.number.isRequired,
-  onPageChange: PropTypes.func.isRequired,
-  onPageSizeChange: PropTypes.func.isRequired,
 };
 
 export default function App() {
@@ -817,7 +662,7 @@ export default function App() {
                 )}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {products.map((p) => (
-                    <TeaCard key={p.id} product={p} onDelete={deleteProduct} onOpen={() => openProductModal(p)} />
+                    <ProductCard key={p.id} product={p} onDelete={deleteProduct} onOpen={() => openProductModal(p)} />
                   ))}
                 </div>
               </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,11 +3,8 @@ import axios from "axios";
 import PropTypes from "prop-types";
 import "./App.css";
 import ProductModal from "./components/ProductModal";
-import ProductCard from "./components/ProductCard";
 import TaskItem from "./components/TaskItem";
-import ProductsFilter from "./components/ProductsFilter";
-import Pagination from "./components/Pagination";
-import { RxUpdate } from "react-icons/rx";
+import ProductsPage from "./components/ProductsPage";
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || "";
 const API = `${BACKEND_URL}/api/v1`;
@@ -344,30 +341,6 @@ export default function App() {
     }
   }, [productsMode, productsTaskId, productsScope, filterKey, currentFilter]);
 
-  const handleFilterChange = React.useCallback(
-    (next) => {
-      setPage(1);
-      if (productsMode === "byTask") {
-        setFilterByTask((prev) => ({ ...prev, [filterKey]: next }));
-      } else {
-        setFilterAll(next);
-      }
-    },
-    [productsMode, filterKey],
-  );
-
-  const handleFilterReset = React.useCallback(() => {
-    setPage(1);
-    if (productsMode === "byTask") {
-      setFilterByTask((prev) => ({
-        ...prev,
-        [filterKey]: { ...DEFAULT_FILTER },
-      }));
-    } else {
-      setFilterAll({ ...DEFAULT_FILTER });
-    }
-  }, [productsMode, filterKey, DEFAULT_FILTER]);
-
   const openProductsForTask = useCallback((taskId, scope = "task") => {
     setProductsMode("byTask");
     setProductsTaskId(taskId);
@@ -613,80 +586,56 @@ export default function App() {
         )}
 
         {activeTab === "products" && (
-          <div className="space-y-6">
-            <div className="bg-white rounded-lg shadow-md p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-semibold">Products ({totalProducts})</h3>
-                <button
-                  onClick={() => {
-                    setPage(1);
-                    fetchProducts().catch(() => {});
-                  }}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2"
-                  title="Refresh results">
-                  <RxUpdate className="w-5 h-5" />
-                  Refresh
-                </button>
-              </div>
-
-              {/* ФИЛЬТР */}
-              <ProductsFilter
-                mode={productsMode}
-                taskId={productsTaskId}
-                scope={productsScope}
-                onScopeChange={(sc) => setProductsScope(sc)}
-                onClearTask={() => {
-                  setProductsMode("all");
-                  setProductsTaskId("");
-                  // при желании сбросить страницу и дернуть фетч:
-                  setPage(1);
-                  // fetchProducts() подтянется из эффекта/кнопки
-                }}
-                characteristics={currentCharacteristics}
-                value={currentFilter}
-                onChange={handleFilterChange}
-                onReset={handleFilterReset}
-                // loading={isFetching}
-                loadingFacets={loadingFacets}
-                onSearchFocusChange={setIsSearchFocused} // NEW
-                onSearchCommit={writeStateToUrl} // NEW: Enter -> сразу обновим URL
-                onSearchTyping={setQLive}
-              />
-
-              <div className="relative">
-                {/* Оверлей загрузки — НЕ меняет layout и НЕ крадёт фокус */}
-                {isFetching && (
-                  <div className="absolute inset-0 z-10 bg-white/60 backdrop-blur-[1px] flex items-center justify-center">
-                    <div className="loading-spinner" aria-label="Loading" />
-                  </div>
-                )}
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {products.map((p) => (
-                    <ProductCard key={p.id} product={p} onDelete={deleteProduct} onOpen={() => openProductModal(p)} />
-                  ))}
-                </div>
-              </div>
-
-              {products.length === 0 && !isFetching && (
-                <div className="text-center py-12">
-                  <div className="text-6xl mb-4">🍃</div>
-                  <p className="text-gray-500">No products found</p>
-                  <p className="text-sm text-gray-400 mt-2">Start scraping to populate the list</p>
-                </div>
-              )}
-
-              <Pagination
-                page={page}
-                totalPages={totalPages}
-                pageSize={pageSize}
-                onPageChange={(p) => setPage(p)}
-                onPageSizeChange={(sz) => {
-                  setPage(1);
-                  setPageSize(sz);
-                }}
-              />
-            </div>
-          </div>
+          <ProductsPage
+            totalProducts={totalProducts}
+            products={products}
+            isFetching={isFetching}
+            productsMode={productsMode}
+            productsTaskId={productsTaskId}
+            productsScope={productsScope}
+            onScopeChange={(sc) => setProductsScope(sc)}
+            onClearTask={() => {
+              setProductsMode("all");
+              setProductsTaskId("");
+              setPage(1);
+            }}
+            currentCharacteristics={currentCharacteristics}
+            currentFilter={currentFilter}
+            onFilterChange={(next) => {
+              setPage(1);
+              if (productsMode === "byTask") {
+                setFilterByTask((prev) => ({ ...prev, [filterKey]: next }));
+              } else {
+                setFilterAll(next);
+              }
+            }}
+            onFilterReset={() => {
+              setPage(1);
+              if (productsMode === "byTask") {
+                setFilterByTask((prev) => ({ ...prev, [filterKey]: { ...DEFAULT_FILTER } }));
+              } else {
+                setFilterAll({ ...DEFAULT_FILTER });
+              }
+            }}
+            loadingFacets={loadingFacets}
+            onSearchFocusChange={setIsSearchFocused}
+            onSearchCommit={writeStateToUrl}
+            onSearchTyping={setQLive}
+            onRefresh={() => {
+              setPage(1);
+              fetchProducts().catch(() => {});
+            }}
+            onDeleteProduct={deleteProduct}
+            onOpenProduct={(p) => openProductModal(p)}
+            page={page}
+            totalPages={totalPages}
+            pageSize={pageSize}
+            onPageChange={(p) => setPage(p)}
+            onPageSizeChange={(sz) => {
+              setPage(1);
+              setPageSize(sz);
+            }}
+          />
         )}
 
         {activeTab === "tasks" && (

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState, useCallback } from "react";
+import PropTypes from "prop-types";
+
+// helpers
+function formatDate(input) {
+  if (!input) return "N/A";
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return "N/A";
+  return d.toLocaleString("en-GB");
+}
+
+function StatusBadge({ status }) {
+  const cls =
+    status === "finished"
+      ? "bg-green-100 text-green-800"
+      : status === "running"
+      ? "bg-blue-100 text-blue-800"
+      : status === "failed"
+      ? "bg-red-100 text-red-800"
+      : status === "pending"
+      ? "bg-yellow-100 text-yellow-800"
+      : "bg-gray-100 text-gray-800";
+  return <span className={`px-2 py-1 rounded-full text-xs font-medium ${cls}`}>{status}</span>;
+}
+StatusBadge.propTypes = { status: PropTypes.string };
+
+function StatCard({ title, value, subtitle, tone = "blue" }) {
+  const toneMap = {
+    blue: "border-blue-500",
+    red: "border-red-500",
+    green: "border-green-500",
+    purple: "border-purple-500",
+    yellow: "border-yellow-500",
+  };
+  const border = toneMap[tone] || toneMap.blue;
+  return (
+    <div className={`bg-white rounded-lg shadow-md p-6 border-l-4 ${border}`}>
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-600">{title}</p>
+          <p className="text-2xl font-bold text-gray-900">{value}</p>
+          {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
+        </div>
+        <div className="text-3xl">📊</div>
+      </div>
+    </div>
+  );
+}
+StatCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  subtitle: PropTypes.string,
+  tone: PropTypes.oneOf(["blue", "red", "green", "purple", "yellow"]),
+};
+
+export default function DashboardPage({ api, onOpenProducts }) {
+  const [stats, setStats] = useState({});
+  const [tasks, setTasks] = useState([]);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [s, t] = await Promise.all([api.get("/stats"), api.get("/tasks?limit=200")]);
+      setStats(s.data || {});
+      setTasks(t.data?.items || t.data || []);
+    } catch {
+      /* noop */
+    }
+  }, [api]);
+
+  useEffect(() => {
+    fetchAll().catch(() => {});
+  }, [fetchAll]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <StatCard title="Products total" value={stats.total_products || 0} subtitle="In database" />
+        <StatCard title="Active tasks" value={stats.running_tasks || 0} subtitle="In progress" />
+        <StatCard title="Finished tasks" value={stats.finished_tasks || 0} subtitle="Succeeded" />
+        <StatCard title="Error rate" value={`${Number(stats.error_rate || 0).toFixed(1)}%`} subtitle="All time" tone="red" />
+      </div>
+
+      {stats.total_products === 0 && (stats.total_tasks || 0) > 0 && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+          <div className="flex items-start">
+            <div className="text-yellow-600 text-2xl mr-4">⚠️</div>
+            <div>
+              <h3 className="text-lg font-semibold text-yellow-800 mb-2">Potential geo-blocking</h3>
+              <p className="text-yellow-700 mb-4">All scraping tasks finish with 0 products. Possible reasons:</p>
+              <ul className="text-yellow-700 space-y-1 mb-4 list-disc list-inside">
+                <li>Geo restrictions for non-Russian IPs</li>
+                <li>Missing tokens or region configuration</li>
+                <li>Cookie ozon_regions is not set</li>
+              </ul>
+              <div className="bg-yellow-100 p-3 rounded-lg text-sm text-yellow-800">
+                Use Russian proxies and set a valid Ozon region cookie.
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">Recent tasks</h3>
+          <button
+            onClick={() => fetchAll().catch(() => {})}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+            🔄 Refresh
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {(tasks || []).slice(0, 5).map((task) => (
+            <div key={task.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+              <div>
+                <p className="font-medium">{task.search_term}</p>
+                <p className="text-sm text-gray-500">{formatDate(task.created_at)}</p>
+                {task.error_message && <p className="text-sm text-red-600 mt-1">{task.error_message}</p>}
+              </div>
+              <div className="flex items-center space-x-3">
+                <span className="text-sm text-gray-600">{task.scraped_products || 0} items</span>
+                <StatusBadge status={task.status} />
+                {onOpenProducts && (
+                  <button
+                    onClick={() => onOpenProducts(task.id, "task")}
+                    className="text-sm px-3 py-1 rounded-lg bg-white border hover:bg-gray-100"
+                    title="Open products for this task">
+                    Open
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {(!tasks || tasks.length === 0) && (
+            <div className="text-center py-12">
+              <div className="text-6xl mb-4">⚙️</div>
+              <p className="text-gray-500">No tasks found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DashboardPage.propTypes = {
+  api: PropTypes.object.isRequired, // axios instance
+  onOpenProducts: PropTypes.func,
+};

--- a/frontend/src/components/Pagination.jsx
+++ b/frontend/src/components/Pagination.jsx
@@ -1,0 +1,69 @@
+// components/Pagination.jsx
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function Pagination({
+  page,
+  totalPages,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [12, 24, 48, 96],
+  className = "",
+}) {
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
+
+  return (
+    <div className={`flex items-center justify-between mt-6 ${className}`}>
+      <div className="flex items-center space-x-2">
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          disabled={!canPrev}
+          className="px-3 py-1 bg-white border rounded-lg disabled:opacity-50"
+          aria-label="Previous page">
+          ← Prev
+        </button>
+
+        <span className="text-sm text-gray-600">
+          Page <strong>{page}</strong> of <strong>{totalPages}</strong>
+        </span>
+
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+          disabled={!canNext}
+          className="px-3 py-1 bg-white border rounded-lg disabled:opacity-50"
+          aria-label="Next page">
+          Next →
+        </button>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <span className="text-sm text-gray-600">Per page:</span>
+        <select
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(parseInt(e.target.value, 10))}
+          className="px-2 py-1 border rounded-lg"
+          aria-label="Items per page">
+          {pageSizeOptions.map((sz) => (
+            <option key={sz} value={sz}>
+              {sz}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+Pagination.propTypes = {
+  page: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  onPageSizeChange: PropTypes.func.isRequired,
+  pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+  className: PropTypes.string,
+};

--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -1,0 +1,182 @@
+// components/TeaProduct.jsx
+import React from "react";
+import PropTypes from "prop-types";
+
+const DateLike = PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]);
+
+const ProductPropType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  name: PropTypes.string,
+  sku: PropTypes.string,
+  created_at: DateLike,
+  updated_at: DateLike,
+  scraped_at: DateLike,
+  cover_image: PropTypes.string,
+  description: PropTypes.shape({
+    content_blocks: PropTypes.arrayOf(
+      PropTypes.shape({
+        img: PropTypes.shape({ alt: PropTypes.string, src: PropTypes.string }),
+      }),
+    ),
+  }),
+  gallery: PropTypes.object,
+  characteristics: PropTypes.shape({
+    full: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+        title: PropTypes.string,
+        values: PropTypes.arrayOf(PropTypes.string),
+      }),
+    ),
+  }),
+});
+
+function formatDate(input) {
+  if (!input) return "N/A";
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return "N/A";
+  return d.toLocaleString("en-GB");
+}
+
+function pickCover(product) {
+  if (product?.cover_image) return product.cover_image;
+  const blocks = product?.description?.content_blocks || [];
+  for (const b of blocks) {
+    if (b?.img?.src) return b.img.src;
+  }
+  const g = product?.gallery;
+  if (g?.images?.length) return g.images[0];
+  return null;
+}
+
+function extractSpecs(product) {
+  const list = product?.characteristics?.full || [];
+  const byId = Object.fromEntries(list.map((x) => [x.id, x]));
+  const byTitle = Object.fromEntries(list.map((x) => [String(x.title || "").toLowerCase(), x]));
+  const pick = (keyId, keyTitle) => {
+    const item = byId[keyId] || byTitle[keyTitle];
+    return item?.values?.filter(Boolean)?.join(", ");
+  };
+  return [
+    { label: "Type", val: pick("TeaType", "вид чая") },
+    { label: "Weight, g", val: pick("Weight", "вес товара, г") },
+    { label: "Taste", val: pick("TeaTaste", "вкус") },
+    { label: "Country", val: pick("Country", "страна-изготовитель") },
+    {
+      label: "Form",
+      val: pick("VarietyTeaShape", "форма чая") || pick("Type", "тип"),
+    },
+  ].filter((x) => x.val);
+}
+
+export default function TeaCard({ product, onDelete, onOpen, size = "large", className = "" }) {
+  const img = pickCover(product);
+  const title = product.title || product.name || product.sku || "Untitled";
+  const specs = extractSpecs(product);
+  const ts = product.updated_at || product.created_at || product.scraped_at;
+
+  if (size === "small") {
+    // Компактная версия (~50% по высоте), горизонтальная компоновка, вертикальное изображение 3:4
+    return (
+      <div
+        className={`bg-white rounded-lg shadow p-3 hover:shadow-md transition-shadow cursor-pointer relative ${className}`}
+        onClick={onOpen}>
+        {/* Кнопка удаления — уменьшенная */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(product.id);
+          }}
+          className="absolute top-2 right-2 z-10 text-red-500 hover:text-red-700 text-xs bg-white/90 rounded-full px-1.5 py-0.5 shadow"
+          title="Delete"
+          aria-label="Delete">
+          ❌
+        </button>
+
+        <div className="flex gap-3">
+          {/* Левая колонка: вертикальное изображение 3:4, фиксируем ширину для контроля высоты */}
+          <div
+            className="shrink-0 rounded-md overflow-hidden bg-gray-100"
+            style={{ aspectRatio: "3 / 4", width: "6.5rem" }} // ~104px ширина -> высота ~138px
+          >
+            {img ? (
+              <img src={img} alt={title} className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-2xl">🍵</div>
+            )}
+          </div>
+
+          {/* Правая колонка: текст, укороченные спецификации */}
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2">{title}</h3>
+
+            <div className="mt-1 space-y-0.5">
+              {specs.slice(0, 2).map((s) => (
+                <div key={s.label} className="flex justify-between gap-2 text-xs">
+                  <span className="text-gray-600">{s.label}:</span>
+                  <span className="font-medium text-gray-900 text-right truncate">{s.val}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-2 flex items-center justify-between text-[11px] text-gray-500">
+              <span>Updated:</span>
+              <span className="truncate">{formatDate(ts)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Полноразмерная версия (как в Products сейчас)
+  return (
+    <div
+      className={`bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow cursor-pointer relative ${className}`}
+      onClick={onOpen}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(product.id);
+        }}
+        className="absolute top-2 right-2 z-10 text-red-500 hover:text-red-700 text-sm bg-white/90 rounded-full px-2 py-1 shadow"
+        title="Delete"
+        aria-label="Delete">
+        ❌
+      </button>
+
+      <div className="flex justify-between items-start mb-3 pr-8">
+        <h3 className="text-base font-semibold text-gray-900 line-clamp-2">{title}</h3>
+      </div>
+
+      {/* В полной версии оставляем текущую широкую обложку */}
+      {img ? (
+        <img src={img} alt={title} className="w-full h-44 object-cover rounded-lg mb-3" />
+      ) : (
+        <div className="w-full h-44 rounded-lg mb-3 bg-gray-100 flex items-center justify-center text-4xl">🍵</div>
+      )}
+
+      <div className="space-y-1 text-sm">
+        {specs.map((s) => (
+          <div key={s.label} className="flex justify-between">
+            <span className="text-gray-600">{s.label}:</span>
+            <span className="font-medium text-gray-900 text-right">{s.val}</span>
+          </div>
+        ))}
+        <div className="flex justify-between text-xs pt-1 text-gray-500">
+          <span>Updated:</span>
+          <span>{formatDate(ts)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+TeaCard.propTypes = {
+  product: ProductPropType.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onOpen: PropTypes.func.isRequired,
+  size: PropTypes.oneOf(["large", "small"]),
+  className: PropTypes.string,
+};

--- a/frontend/src/components/ProductsPage.jsx
+++ b/frontend/src/components/ProductsPage.jsx
@@ -15,11 +15,11 @@ const DEFAULT_FILTER = {
 };
 
 const DEFAULT_QUERY = {
-  mode: "all",        // "all" | "byTask"
+  mode: "all", // "all" | "byTask"
   taskId: "",
-  scope: "task",      // "task" | "pipeline"
+  scope: "task", // "task" | "pipeline"
   page: 1,
-  limit: 24,          // 12|24|48|96
+  limit: 24, // 12|24|48|96
   ...DEFAULT_FILTER,
 };
 
@@ -131,10 +131,7 @@ export default function ProductsPage({ api, initialQuery, onPersist }) {
   const productsAbortRef = useRef(null);
   const facetsAbortRef = useRef(null);
 
-  const totalPages = useMemo(
-    () => Math.max(1, Math.ceil(Number(totalProducts || 0) / Number(pageSize || 1))),
-    [totalProducts, pageSize],
-  );
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(Number(totalProducts || 0) / Number(pageSize || 1))), [totalProducts, pageSize]);
 
   // --- apply a full query object into component state
   const applyQuery = useCallback((q) => {
@@ -180,7 +177,7 @@ export default function ProductsPage({ api, initialQuery, onPersist }) {
   // ----- initialization (sync to avoid гонки) -----
   useLayoutEffect(() => {
     const urlHas = hasProductsParamsInUrl(window.location.search);
-    const snap = urlHas ? readQueryFromUrl(window.location.search) : (initialQuery || DEFAULT_QUERY);
+    const snap = urlHas ? readQueryFromUrl(window.location.search) : initialQuery || DEFAULT_QUERY;
     applyQuery(snap);
     // стандартизируем URL под выбранный снапшот
     writeQueryToUrl(snap);
@@ -273,17 +270,7 @@ export default function ProductsPage({ api, initialQuery, onPersist }) {
     if (!didInit) return;
     fetchProducts().catch(() => {});
     fetchFilterCharacteristics().catch(() => {});
-  }, [
-    didInit,
-    fetchProducts,
-    fetchFilterCharacteristics,
-    currentFilter,
-    page,
-    pageSize,
-    productsMode,
-    productsTaskId,
-    productsScope,
-  ]);
+  }, [didInit, fetchProducts, fetchFilterCharacteristics, currentFilter, page, pageSize, productsMode, productsTaskId, productsScope]);
 
   // ----- modal helpers -----
   const openProductModal = useCallback(
@@ -347,97 +334,97 @@ export default function ProductsPage({ api, initialQuery, onPersist }) {
 
   // ----- render -----
   return (
-    <div className="space-y-6">
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold">Products ({totalProducts})</h3>
-          <button
-            onClick={() => {
-              setPage(1);
-              fetchProducts().catch(() => {});
+    <>
+      <div className="space-y-6">
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold">Products ({totalProducts})</h3>
+            <button
+              onClick={() => {
+                setPage(1);
+                fetchProducts().catch(() => {});
+              }}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2"
+              title="Refresh results">
+              <RxUpdate className="w-5 h-5" />
+              Refresh
+            </button>
+          </div>
+
+          <ProductsFilter
+            mode={productsMode}
+            taskId={productsTaskId}
+            scope={productsScope}
+            onScopeChange={setProductsScope}
+            onClearTask={handleClearTask}
+            characteristics={currentCharacteristics}
+            value={currentFilter}
+            onChange={handleFilterChange}
+            onReset={handleFilterReset}
+            loadingFacets={loadingFacets}
+            onSearchFocusChange={setIsSearchFocused}
+            onSearchCommit={() => {
+              const q = buildCurrentQuery();
+              writeQueryToUrl(q);
             }}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2"
-            title="Refresh results"
-          >
-            <RxUpdate className="w-5 h-5" />
-            Refresh
-          </button>
-        </div>
+            onSearchTyping={setQLive}
+          />
 
-        <ProductsFilter
-          mode={productsMode}
-          taskId={productsTaskId}
-          scope={productsScope}
-          onScopeChange={setProductsScope}
-          onClearTask={handleClearTask}
-          characteristics={currentCharacteristics}
-          value={currentFilter}
-          onChange={handleFilterChange}
-          onReset={handleFilterReset}
-          loadingFacets={loadingFacets}
-          onSearchFocusChange={setIsSearchFocused}
-          onSearchCommit={() => {
-            const q = buildCurrentQuery();
-            writeQueryToUrl(q);
-          }}
-          onSearchTyping={setQLive}
-        />
+          <div className="relative">
+            {isFetching && (
+              <div className="absolute inset-0 z-10 bg-white/60 backdrop-blur-[1px] flex items-center justify-center">
+                <div className="loading-spinner" aria-label="Loading" />
+              </div>
+            )}
 
-        <div className="relative">
-          {isFetching && (
-            <div className="absolute inset-0 z-10 bg-white/60 backdrop-blur-[1px] flex items-center justify-center">
-              <div className="loading-spinner" aria-label="Loading" />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {products.map((p) => (
+                <ProductCard
+                  key={p.id}
+                  product={p}
+                  onDelete={async (id) => {
+                    if (!window.confirm("Delete this product?")) return;
+                    await api.delete(`/products/${id}`);
+                    fetchProducts().catch(() => {});
+                  }}
+                  onOpen={() => openProductModal(p)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {products.length === 0 && !isFetching && (
+            <div className="text-center py-12">
+              <div className="text-6xl mb-4">🍃</div>
+              <p className="text-gray-500">No products found</p>
+              <p className="text-sm text-gray-400 mt-2">Start scraping to populate the list</p>
             </div>
           )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {products.map((p) => (
-              <ProductCard
-                key={p.id}
-                product={p}
-                onDelete={async (id) => {
-                  if (!window.confirm("Delete this product?")) return;
-                  await api.delete(`/products/${id}`);
-                  fetchProducts().catch(() => {});
-                }}
-                onOpen={() => openProductModal(p)}
-              />
-            ))}
-          </div>
+          <Pagination
+            page={page}
+            totalPages={totalPages}
+            pageSize={pageSize}
+            onPageChange={(p) => setPage(p)}
+            onPageSizeChange={(sz) => {
+              setPage(1);
+              setPageSize(sz);
+            }}
+          />
         </div>
-
-        {products.length === 0 && !isFetching && (
-          <div className="text-center py-12">
-            <div className="text-6xl mb-4">🍃</div>
-            <p className="text-gray-500">No products found</p>
-            <p className="text-sm text-gray-400 mt-2">Start scraping to populate the list</p>
-          </div>
-        )}
-
-        <Pagination
-          page={page}
-          totalPages={totalPages}
-          pageSize={pageSize}
-          onPageChange={(p) => setPage(p)}
-          onPageSizeChange={(sz) => {
-            setPage(1);
-            setPageSize(sz);
-          }}
-        />
       </div>
-
       <ProductModal
         isOpen={isProductModalOpen}
         product={modalProduct || {}}
         onClose={closeProductModal}
         onSelectSku={(sku) => openProductModal(sku)}
       />
-    </div>
+    </>
   );
 }
 
 ProductsPage.propTypes = {
-  api: PropTypes.object.isRequired,          // axios instance
+  api: PropTypes.object.isRequired, // axios instance
   initialQuery: PropTypes.shape({
     mode: PropTypes.oneOf(["all", "byTask"]),
     taskId: PropTypes.string,
@@ -449,7 +436,7 @@ ProductsPage.propTypes = {
     sort_dir: PropTypes.oneOf(["asc", "desc"]),
     filters: PropTypes.object, // Record<string, string[]>
   }),
-  onPersist: PropTypes.func,                 // (queryObj) => void
+  onPersist: PropTypes.func, // (queryObj) => void
 };
 
 ProductsPage.defaultProps = {

--- a/frontend/src/components/ProductsPage.jsx
+++ b/frontend/src/components/ProductsPage.jsx
@@ -182,7 +182,6 @@ export default function ProductsPage({ api, initialQuery, onPersist }) {
     // стандартизируем URL под выбранный снапшот
     writeQueryToUrl(snap);
     setDidInit(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // один раз на маунт
 
   // ----- sync URL + persist to parent when state changes -----

--- a/frontend/src/components/ProductsPage.jsx
+++ b/frontend/src/components/ProductsPage.jsx
@@ -1,0 +1,142 @@
+// components/ProductsPage.jsx
+import React from "react";
+import PropTypes from "prop-types";
+import { RxUpdate } from "react-icons/rx";
+import ProductsFilter from "./ProductsFilter";
+import Pagination from "./Pagination";
+import ProductCard from "./ProductCard";
+
+export default function ProductsPage({
+  totalProducts,
+  products,
+  isFetching,
+
+  // фильтрация / режим
+  productsMode, // "all" | "byTask"
+  productsTaskId, // string
+  productsScope, // "task" | "pipeline"
+  onScopeChange, // (scope) => void
+  onClearTask, // () => void
+
+  currentCharacteristics, // Characteristic[]
+  currentFilter, // { q, sort_by, sort_dir, filters }
+  onFilterChange, // (nextFilter) => void
+  onFilterReset, // () => void
+  loadingFacets, // boolean
+  onSearchFocusChange, // (bool) => void
+  onSearchCommit, // () => void
+  onSearchTyping, // (text) => void
+
+  // действия
+  onRefresh, // () => void
+  onDeleteProduct, // (id) => Promise<void>
+  onOpenProduct, // (product|sku) => void
+
+  // пагинация
+  page,
+  totalPages,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">Products ({totalProducts})</h3>
+          <button
+            onClick={onRefresh}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2"
+            title="Refresh results">
+            <RxUpdate className="w-5 h-5" />
+            Refresh
+          </button>
+        </div>
+
+        {/* ФИЛЬТР */}
+        <ProductsFilter
+          mode={productsMode}
+          taskId={productsTaskId}
+          scope={productsScope}
+          onScopeChange={onScopeChange}
+          onClearTask={onClearTask}
+          characteristics={currentCharacteristics}
+          value={currentFilter}
+          onChange={onFilterChange}
+          onReset={onFilterReset}
+          loadingFacets={loadingFacets}
+          onSearchFocusChange={onSearchFocusChange}
+          onSearchCommit={onSearchCommit}
+          onSearchTyping={onSearchTyping}
+        />
+
+        <div className="relative">
+          {/* Оверлей загрузки — НЕ меняет layout и НЕ крадёт фокус */}
+          {isFetching && (
+            <div className="absolute inset-0 z-10 bg-white/60 backdrop-blur-[1px] flex items-center justify-center">
+              <div className="loading-spinner" aria-label="Loading" />
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {products.map((p) => (
+              <ProductCard key={p.id} product={p} onDelete={onDeleteProduct} onOpen={() => onOpenProduct(p)} />
+            ))}
+          </div>
+        </div>
+
+        {products.length === 0 && !isFetching && (
+          <div className="text-center py-12">
+            <div className="text-6xl mb-4">🍃</div>
+            <p className="text-gray-500">No products found</p>
+            <p className="text-sm text-gray-400 mt-2">Start scraping to populate the list</p>
+          </div>
+        )}
+
+        <Pagination
+          page={page}
+          totalPages={totalPages}
+          pageSize={pageSize}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+ProductsPage.propTypes = {
+  totalProducts: PropTypes.number.isRequired,
+  products: PropTypes.array.isRequired,
+  isFetching: PropTypes.bool.isRequired,
+
+  productsMode: PropTypes.oneOf(["all", "byTask"]).isRequired,
+  productsTaskId: PropTypes.string,
+  productsScope: PropTypes.oneOf(["task", "pipeline"]).isRequired,
+  onScopeChange: PropTypes.func.isRequired,
+  onClearTask: PropTypes.func.isRequired,
+
+  currentCharacteristics: PropTypes.array.isRequired,
+  currentFilter: PropTypes.shape({
+    q: PropTypes.string,
+    sort_by: PropTypes.string,
+    sort_dir: PropTypes.oneOf(["asc", "desc"]),
+    filters: PropTypes.object,
+  }).isRequired,
+  onFilterChange: PropTypes.func.isRequired,
+  onFilterReset: PropTypes.func.isRequired,
+  loadingFacets: PropTypes.bool.isRequired,
+  onSearchFocusChange: PropTypes.func.isRequired,
+  onSearchCommit: PropTypes.func.isRequired,
+  onSearchTyping: PropTypes.func.isRequired,
+
+  onRefresh: PropTypes.func.isRequired,
+  onDeleteProduct: PropTypes.func.isRequired,
+  onOpenProduct: PropTypes.func.isRequired,
+
+  page: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  onPageSizeChange: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/ProductsPage.jsx
+++ b/frontend/src/components/ProductsPage.jsx
@@ -1,51 +1,314 @@
 // components/ProductsPage.jsx
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { RxUpdate } from "react-icons/rx";
 import ProductsFilter from "./ProductsFilter";
 import Pagination from "./Pagination";
 import ProductCard from "./ProductCard";
+import ProductModal from "./ProductModal";
 
-export default function ProductsPage({
-  totalProducts,
-  products,
-  isFetching,
+const DEFAULT_FILTER = {
+  q: "",
+  sort_by: "updated_at",
+  sort_dir: "desc",
+  filters: {}, // Record<charId, string[]>
+};
 
-  // фильтрация / режим
-  productsMode, // "all" | "byTask"
-  productsTaskId, // string
-  productsScope, // "task" | "pipeline"
-  onScopeChange, // (scope) => void
-  onClearTask, // () => void
+export default function ProductsPage({ api }) {
+  // ----- state -----
+  const [products, setProducts] = useState([]);
+  const [totalProducts, setTotalProducts] = useState(0);
 
-  currentCharacteristics, // Characteristic[]
-  currentFilter, // { q, sort_by, sort_dir, filters }
-  onFilterChange, // (nextFilter) => void
-  onFilterReset, // () => void
-  loadingFacets, // boolean
-  onSearchFocusChange, // (bool) => void
-  onSearchCommit, // () => void
-  onSearchTyping, // (text) => void
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(24);
 
-  // действия
-  onRefresh, // () => void
-  onDeleteProduct, // (id) => Promise<void>
-  onOpenProduct, // (product|sku) => void
+  const [productsMode, setProductsMode] = useState("all"); // "all" | "byTask"
+  const [productsTaskId, setProductsTaskId] = useState("");
+  const [productsScope, setProductsScope] = useState("task"); // "task" | "pipeline"
 
-  // пагинация
-  page,
-  totalPages,
-  pageSize,
-  onPageChange,
-  onPageSizeChange,
-}) {
+  const [filterAll, setFilterAll] = useState({ ...DEFAULT_FILTER });
+  const [filterByTask, setFilterByTask] = useState({}); // {[key]: FilterValue}
+  const filterKey = useMemo(
+    () => (productsMode === "byTask" ? `${productsTaskId || ""}::${productsScope}` : "all"),
+    [productsMode, productsTaskId, productsScope],
+  );
+  const currentFilter = useMemo(
+    () => (productsMode === "byTask" ? filterByTask[filterKey] || DEFAULT_FILTER : filterAll),
+    [productsMode, filterByTask, filterKey, filterAll],
+  );
+
+  const [charAll, setCharAll] = useState([]);
+  const [charByTask, setCharByTask] = useState({});
+  const currentCharacteristics = useMemo(
+    () => (productsMode === "byTask" ? charByTask[filterKey] || [] : charAll),
+    [productsMode, charByTask, filterKey, charAll],
+  );
+
+  const [isFetching, setIsFetching] = useState(false);
+  const [loadingFacets, setLoadingFacets] = useState(false);
+
+  // URL sync helpers
+  const [didInitFromUrl, setDidInitFromUrl] = useState(false);
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [qLive, setQLive] = useState("");
+  const [qDebounced, setQDebounced] = useState("");
+  useEffect(() => setQDebounced(currentFilter.q || ""), [currentFilter.q]);
+
+  // modal
+  const [isProductModalOpen, setIsProductModalOpen] = useState(false);
+  const [modalProduct, setModalProduct] = useState(null);
+
+  // abort controllers
+  const productsAbortRef = useRef(null);
+  const facetsAbortRef = useRef(null);
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(Number(totalProducts || 0) / Number(pageSize || 1))), [totalProducts, pageSize]);
+
+  // ----- URL <-> state -----
+  const parseUrlToState = useCallback(() => {
+    const sp = new URLSearchParams(window.location.search);
+    const mode = sp.get("mode");
+    const taskId = sp.get("taskId");
+    const scope = sp.get("scope");
+    const q = sp.get("q") || "";
+    const sort_by = sp.get("sort_by") || "updated_at";
+    const sort_dir = (sp.get("sort_dir") || "desc") === "asc" ? "asc" : "desc";
+    const pageQ = parseInt(sp.get("page") || "1", 10);
+    const limitQ = parseInt(sp.get("limit") || "24", 10);
+
+    // собрать char_* -> Record<string,string[]>
+    const filters = {};
+    for (const [k, v] of sp.entries()) {
+      if (k.startsWith("char_") && v) {
+        const cid = k.slice(5);
+        (filters[cid] ??= []).push(v);
+      }
+    }
+
+    if (Number.isFinite(pageQ) && pageQ > 0) setPage(pageQ);
+    if (Number.isFinite(limitQ) && [12, 24, 48, 96].includes(limitQ)) setPageSize(limitQ);
+
+    const parsedFilter = { q, sort_by, sort_dir, filters };
+    if (mode === "byTask" && taskId) {
+      setProductsMode("byTask");
+      setProductsTaskId(taskId);
+      setProductsScope(scope === "pipeline" ? "pipeline" : "task");
+      const key = `${taskId}::${scope === "pipeline" ? "pipeline" : "task"}`;
+      setFilterByTask((prev) => ({ ...prev, [key]: parsedFilter }));
+    } else {
+      setProductsMode("all");
+      setFilterAll(parsedFilter);
+    }
+  }, []);
+
+  const writeStateToUrl = useCallback(() => {
+    if (!didInitFromUrl) return;
+    const sp = new URLSearchParams(window.location.search);
+
+    // NB: tab управляется App; здесь трогаем только product-параметры
+    sp.set("mode", productsMode);
+    if (productsMode === "byTask" && productsTaskId) {
+      sp.set("taskId", productsTaskId);
+      sp.set("scope", productsScope);
+    } else {
+      sp.delete("taskId");
+      sp.delete("scope");
+    }
+
+    sp.set("page", String(page));
+    sp.set("limit", String(pageSize));
+    const qParam = isSearchFocused ? qLive : currentFilter.q || "";
+    if (qParam) sp.set("q", qParam);
+    else sp.delete("q");
+
+    sp.set("sort_by", currentFilter.sort_by || "updated_at");
+    sp.set("sort_dir", currentFilter.sort_dir || "desc");
+
+    // сбросить старые char_*, затем записать заново
+    [...sp.keys()].forEach((k) => k.startsWith("char_") && sp.delete(k));
+    Object.entries(currentFilter.filters || {}).forEach(([cid, vals]) => {
+      (vals || []).forEach((v) => sp.append(`char_${cid}`, v));
+    });
+
+    const nextUrl = `${window.location.pathname}?${sp.toString()}`;
+    if (nextUrl !== `${window.location.pathname}${window.location.search}`) {
+      window.history.replaceState(null, "", nextUrl);
+    }
+  }, [didInitFromUrl, productsMode, productsTaskId, productsScope, page, pageSize, isSearchFocused, qLive, currentFilter]);
+
+  // ----- data fetching -----
+  const fetchProducts = useCallback(async () => {
+    setIsFetching(true);
+    try {
+      if (productsAbortRef.current) productsAbortRef.current.abort();
+      productsAbortRef.current = new AbortController();
+
+      // build common params
+      const params = new URLSearchParams();
+      params.set("limit", String(pageSize));
+      params.set("skip", String((page - 1) * pageSize));
+      if (currentFilter.q) params.set("q", currentFilter.q);
+      params.set("sort_by", currentFilter.sort_by || "updated_at");
+      params.set("sort_dir", currentFilter.sort_dir || "desc");
+      Object.entries(currentFilter.filters || {}).forEach(([cid, vals]) => {
+        (vals || []).forEach((v) => params.append(`char_${cid}`, v));
+      });
+
+      if (productsMode === "byTask" && productsTaskId) {
+        params.set("scope", productsScope);
+        const url = `/tasks/${encodeURIComponent(productsTaskId)}/products?${params.toString()}`;
+        const res = await api.get(url, { signal: productsAbortRef.current.signal });
+        setProducts(res.data?.items || []);
+        setTotalProducts(res.data?.total || 0);
+      } else {
+        const url = `/products?${params.toString()}`;
+        const res = await api.get(url, { signal: productsAbortRef.current.signal });
+        setProducts(res.data?.items || []);
+        setTotalProducts(res.data?.total || 0);
+      }
+    } finally {
+      setIsFetching(false);
+    }
+  }, [api, page, pageSize, productsMode, productsTaskId, productsScope, currentFilter]);
+
+  const fetchFilterCharacteristics = useCallback(async () => {
+    try {
+      setLoadingFacets(true);
+      if (facetsAbortRef.current) facetsAbortRef.current.abort();
+      facetsAbortRef.current = new AbortController();
+
+      const facetParams = new URLSearchParams();
+      if (currentFilter.q) facetParams.set("q", currentFilter.q);
+      Object.entries(currentFilter.filters || {}).forEach(([cid, vals]) => {
+        (vals || []).forEach((v) => facetParams.append(`char_${cid}`, v));
+      });
+
+      if (productsMode === "byTask" && productsTaskId) {
+        facetParams.set("scope", productsScope);
+        const url = `/tasks/${encodeURIComponent(productsTaskId)}/products/characteristics?${facetParams.toString()}`;
+        const res = await api.get(url, { signal: facetsAbortRef.current.signal });
+        const arr = Array.isArray(res.data) ? res.data : [];
+        setCharByTask((prev) => ({ ...prev, [filterKey]: arr }));
+      } else {
+        const url = `/products/characteristics?${facetParams.toString()}`;
+        const res = await api.get(url, { signal: facetsAbortRef.current.signal });
+        setCharAll(Array.isArray(res.data) ? res.data : res.data?.items || []);
+      }
+    } catch {
+      /* noop */
+    } finally {
+      setLoadingFacets(false);
+    }
+  }, [api, productsMode, productsTaskId, productsScope, filterKey, currentFilter]);
+
+  // ----- modal helpers -----
+  const openProductModal = useCallback(
+    (prodOrSku) => {
+      if (!prodOrSku) return;
+      if (typeof prodOrSku === "object") {
+        setModalProduct(prodOrSku);
+        setIsProductModalOpen(true);
+        return;
+      }
+      // try find on page
+      const found = products.find((p) => String(p.sku) === String(prodOrSku));
+      if (found) {
+        setModalProduct(found);
+        setIsProductModalOpen(true);
+        return;
+      }
+      // fallback: fetch by SKU
+      api
+        .get(`/products/sku/${encodeURIComponent(String(prodOrSku))}`)
+        .then((res) => {
+          if (res?.data) {
+            setModalProduct(res.data);
+            setIsProductModalOpen(true);
+          }
+        })
+        .catch(() => {});
+    },
+    [api, products],
+  );
+  const closeProductModal = useCallback(() => {
+    setIsProductModalOpen(false);
+    setModalProduct(null);
+  }, []);
+
+  // ----- handlers passed to children -----
+  const handleFilterChange = useCallback(
+    (next) => {
+      setPage(1);
+      if (productsMode === "byTask") {
+        setFilterByTask((prev) => ({ ...prev, [filterKey]: next }));
+      } else {
+        setFilterAll(next);
+      }
+    },
+    [productsMode, filterKey],
+  );
+
+  const handleFilterReset = useCallback(() => {
+    setPage(1);
+    if (productsMode === "byTask") {
+      setFilterByTask((prev) => ({ ...prev, [filterKey]: { ...DEFAULT_FILTER } }));
+    } else {
+      setFilterAll({ ...DEFAULT_FILTER });
+    }
+  }, [productsMode, filterKey]);
+
+  const handleClearTask = useCallback(() => {
+    setProductsMode("all");
+    setProductsTaskId("");
+    setPage(1);
+  }, []);
+
+  const deleteProduct = useCallback(
+    async (productId) => {
+      if (!window.confirm("Delete this product?")) return;
+      await api.delete(`/products/${productId}`);
+      fetchProducts().catch(() => {});
+    },
+    [api, fetchProducts],
+  );
+
+  // ----- lifecycle -----
+  useEffect(() => {
+    parseUrlToState();
+    setDidInitFromUrl(true);
+  }, [parseUrlToState]);
+
+  useEffect(() => {
+    writeStateToUrl();
+  }, [writeStateToUrl]);
+
+  useEffect(() => {
+    if (!didInitFromUrl) return;
+    fetchProducts().catch(() => {});
+    fetchFilterCharacteristics().catch(() => {});
+  }, [
+    didInitFromUrl,
+    fetchProducts,
+    fetchFilterCharacteristics,
+    currentFilter,
+    page,
+    pageSize,
+    productsMode,
+    productsTaskId,
+    productsScope,
+  ]);
+
+  // ----- render -----
   return (
     <div className="space-y-6">
       <div className="bg-white rounded-lg shadow-md p-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-semibold">Products ({totalProducts})</h3>
           <button
-            onClick={onRefresh}
+            onClick={() => {
+              setPage(1);
+              fetchProducts().catch(() => {});
+            }}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center gap-2"
             title="Refresh results">
             <RxUpdate className="w-5 h-5" />
@@ -53,25 +316,23 @@ export default function ProductsPage({
           </button>
         </div>
 
-        {/* ФИЛЬТР */}
         <ProductsFilter
           mode={productsMode}
           taskId={productsTaskId}
           scope={productsScope}
-          onScopeChange={onScopeChange}
-          onClearTask={onClearTask}
+          onScopeChange={setProductsScope}
+          onClearTask={handleClearTask}
           characteristics={currentCharacteristics}
           value={currentFilter}
-          onChange={onFilterChange}
-          onReset={onFilterReset}
+          onChange={handleFilterChange}
+          onReset={handleFilterReset}
           loadingFacets={loadingFacets}
-          onSearchFocusChange={onSearchFocusChange}
-          onSearchCommit={onSearchCommit}
-          onSearchTyping={onSearchTyping}
+          onSearchFocusChange={setIsSearchFocused}
+          onSearchCommit={writeStateToUrl}
+          onSearchTyping={setQLive}
         />
 
         <div className="relative">
-          {/* Оверлей загрузки — НЕ меняет layout и НЕ крадёт фокус */}
           {isFetching && (
             <div className="absolute inset-0 z-10 bg-white/60 backdrop-blur-[1px] flex items-center justify-center">
               <div className="loading-spinner" aria-label="Loading" />
@@ -80,7 +341,7 @@ export default function ProductsPage({
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {products.map((p) => (
-              <ProductCard key={p.id} product={p} onDelete={onDeleteProduct} onOpen={() => onOpenProduct(p)} />
+              <ProductCard key={p.id} product={p} onDelete={deleteProduct} onOpen={() => openProductModal(p)} />
             ))}
           </div>
         </div>
@@ -97,46 +358,24 @@ export default function ProductsPage({
           page={page}
           totalPages={totalPages}
           pageSize={pageSize}
-          onPageChange={onPageChange}
-          onPageSizeChange={onPageSizeChange}
+          onPageChange={(p) => setPage(p)}
+          onPageSizeChange={(sz) => {
+            setPage(1);
+            setPageSize(sz);
+          }}
         />
       </div>
+
+      <ProductModal
+        isOpen={isProductModalOpen}
+        product={modalProduct || {}}
+        onClose={closeProductModal}
+        onSelectSku={(sku) => openProductModal(sku)}
+      />
     </div>
   );
 }
 
 ProductsPage.propTypes = {
-  totalProducts: PropTypes.number.isRequired,
-  products: PropTypes.array.isRequired,
-  isFetching: PropTypes.bool.isRequired,
-
-  productsMode: PropTypes.oneOf(["all", "byTask"]).isRequired,
-  productsTaskId: PropTypes.string,
-  productsScope: PropTypes.oneOf(["task", "pipeline"]).isRequired,
-  onScopeChange: PropTypes.func.isRequired,
-  onClearTask: PropTypes.func.isRequired,
-
-  currentCharacteristics: PropTypes.array.isRequired,
-  currentFilter: PropTypes.shape({
-    q: PropTypes.string,
-    sort_by: PropTypes.string,
-    sort_dir: PropTypes.oneOf(["asc", "desc"]),
-    filters: PropTypes.object,
-  }).isRequired,
-  onFilterChange: PropTypes.func.isRequired,
-  onFilterReset: PropTypes.func.isRequired,
-  loadingFacets: PropTypes.bool.isRequired,
-  onSearchFocusChange: PropTypes.func.isRequired,
-  onSearchCommit: PropTypes.func.isRequired,
-  onSearchTyping: PropTypes.func.isRequired,
-
-  onRefresh: PropTypes.func.isRequired,
-  onDeleteProduct: PropTypes.func.isRequired,
-  onOpenProduct: PropTypes.func.isRequired,
-
-  page: PropTypes.number.isRequired,
-  totalPages: PropTypes.number.isRequired,
-  pageSize: PropTypes.number.isRequired,
-  onPageChange: PropTypes.func.isRequired,
-  onPageSizeChange: PropTypes.func.isRequired,
+  api: PropTypes.object.isRequired, // axios instance
 };

--- a/frontend/src/components/ScrapingPage.jsx
+++ b/frontend/src/components/ScrapingPage.jsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+
+export default function ScrapingPage({ api }) {
+  const [searchTerm, setSearchTerm] = useState("puer");
+  const [loading, setLoading] = useState(false);
+  const [stats, setStats] = useState({});
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await api.get("/stats");
+      setStats(res.data || {});
+    } catch {
+      /* noop */
+    }
+  }, [api]);
+
+  useEffect(() => {
+    fetchStats().catch(() => {});
+  }, [fetchStats]);
+
+  const startScraping = useCallback(async () => {
+    const term = String(searchTerm || "").trim();
+    if (!term) return;
+    setLoading(true);
+    try {
+      const res = await api.post(`/scrape/start?search_term=${encodeURIComponent(term)}`);
+      window.alert(`Scraping started. Task ID: ${res.data?.task_id || "N/A"}`);
+      fetchStats().catch(() => {});
+    } catch {
+      window.alert("Failed to start scraping.");
+    } finally {
+      setLoading(false);
+    }
+  }, [api, searchTerm, fetchStats]);
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h3 className="text-lg font-semibold mb-4">Start scraping</h3>
+        <div className="flex items-center space-x-4">
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="Enter a search query (e.g. 'puer')"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+          <button
+            onClick={startScraping}
+            disabled={loading}
+            className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition-colors">
+            {loading ? "🔄 Starting..." : "🚀 Start"}
+          </button>
+        </div>
+
+        <div className="mt-4 p-4 bg-blue-50 rounded-lg">
+          <h4 className="font-medium text-blue-900 mb-2">Suggested queries</h4>
+          <div className="flex flex-wrap gap-2">
+            {["puer", "sheng puer", "shu puer", "oolong", "chinese tea", "green tea"].map((term) => (
+              <button
+                key={term}
+                onClick={() => setSearchTerm(term)}
+                className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm hover:bg-blue-200 transition-colors">
+                {term}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h3 className="text-lg font-semibold mb-4">Scraping statistics</h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="p-4 bg-green-50 rounded-lg">
+            <div className="text-green-600 text-sm font-medium">Captchas solved</div>
+            <div className="text-2xl font-bold text-green-900">{stats.captcha_solves || 0}</div>
+          </div>
+          <div className="p-4 bg-blue-50 rounded-lg">
+            <div className="text-blue-600 text-sm font-medium">Total tasks</div>
+            <div className="text-2xl font-bold text-blue-900">{stats.total_tasks || 0}</div>
+          </div>
+          <div className="p-4 bg-purple-50 rounded-lg">
+            <div className="text-purple-600 text-sm font-medium">Success rate</div>
+            <div className="text-2xl font-bold text-purple-900">
+              {stats.total_tasks > 0 ? ((Number(stats.finished_tasks || 0) / Number(stats.total_tasks || 1)) * 100).toFixed(1) : 0}%
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ScrapingPage.propTypes = {
+  api: PropTypes.object.isRequired, // axios instance
+};

--- a/frontend/src/components/TasksPage.jsx
+++ b/frontend/src/components/TasksPage.jsx
@@ -1,0 +1,123 @@
+// components/TasksPage.jsx
+import React, { useCallback, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import TaskItem from "./TaskItem";
+
+export default function TasksPage({ api, onOpenProducts }) {
+  const [tasks, setTasks] = useState([]);
+  const [tasksParentFilter, setTasksParentFilter] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  // --- URL <-> state (только для tasks_parent_id)
+  const parseUrlToState = useCallback(() => {
+    const sp = new URLSearchParams(window.location.search);
+    const parent = sp.get("tasks_parent_id") || "";
+    setTasksParentFilter(parent);
+  }, []);
+
+  const writeStateToUrl = useCallback(() => {
+    const sp = new URLSearchParams(window.location.search);
+    if (tasksParentFilter) sp.set("tasks_parent_id", tasksParentFilter);
+    else sp.delete("tasks_parent_id");
+    const next = `${window.location.pathname}?${sp.toString()}`;
+    if (next !== `${window.location.pathname}${window.location.search}`) {
+      window.history.replaceState(null, "", next);
+    }
+  }, [tasksParentFilter]);
+
+  const fetchTasks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (tasksParentFilter) params.set("parent_task_id", tasksParentFilter);
+      params.set("limit", "200");
+      const res = await api.get(`/tasks?${params.toString()}`);
+      const items = res.data?.items || res.data || [];
+      setTasks(items);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, tasksParentFilter]);
+
+  const openChildrenTasks = useCallback((taskId) => {
+    setTasksParentFilter(taskId);
+  }, []);
+
+  const clearParent = useCallback(() => {
+    setTasksParentFilter("");
+  }, []);
+
+  // init
+  useEffect(() => {
+    parseUrlToState();
+  }, [parseUrlToState]);
+
+  // keep URL in sync with local state
+  useEffect(() => {
+    writeStateToUrl();
+  }, [writeStateToUrl]);
+
+  // load data
+  useEffect(() => {
+    fetchTasks().catch(() => {});
+  }, [fetchTasks]);
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">Task history</h3>
+          <div className="flex items-center gap-2">
+            {tasksParentFilter && (
+              <button
+                onClick={clearParent}
+                className="px-3 py-1.5 bg-white border rounded-lg hover:bg-gray-50"
+                title="Clear parent filter"
+              >
+                ✖ Clear parent
+              </button>
+            )}
+            <button
+              onClick={() => fetchTasks().catch(() => {})}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              🔄 Refresh
+            </button>
+          </div>
+        </div>
+
+        {tasksParentFilter && (
+          <div className="mb-3 text-sm text-gray-600">
+            Parent filter: <code className="bg-gray-100 px-1.5 py-0.5 rounded">{tasksParentFilter}</code>
+          </div>
+        )}
+
+        {loading && (
+          <div className="py-6 text-center text-gray-500">Loading…</div>
+        )}
+
+        <div className="space-y-3">
+          {tasks.map((t) => (
+            <TaskItem
+              key={t.id}
+              task={t}
+              onOpenProducts={onOpenProducts}
+              onOpenChildren={openChildrenTasks}
+            />
+          ))}
+          {!loading && tasks.length === 0 && (
+            <div className="text-center py-12">
+              <div className="text-6xl mb-4">⚙️</div>
+              <p className="text-gray-500">No tasks found</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+TasksPage.propTypes = {
+  api: PropTypes.object.isRequired,                // axios instance
+  onOpenProducts: PropTypes.func.isRequired,       // (taskId, scope) => void
+};


### PR DESCRIPTION
## What changed
- Split the monolithic `App.js` into dedicated pages:
  - `components/DashboardPage.jsx`
  - `components/ScrapingPage.jsx`
  - `components/TasksPage.jsx`
  - `components/ProductsPage.jsx`
- Moved pagination into `components/Pagination.jsx` (reusable).
- Centralized all product-related logic inside `ProductsPage`:
  - Parses **product** query params from the URL and writes them back (`mode`, `taskId`, `scope`, `q`, `sort_by`, `sort_dir`, `page`, `limit`, `char_*` filters).
  - Persists filters/sort/page across tab switches via the `initialQuery` / `onPersist` pattern:
    - `App` keeps the last product query in `lastProductsQuery`.
    - On mount, `ProductsPage` prefers URL params if present; otherwise falls back to `initialQuery`.
- `App` now controls **only** the active tab and guarantees URL contains just `?tab=...` for non-product tabs.
  - When tab = `products`, the full product query string remains in the URL and is maintained by `ProductsPage`.
- Deep-linking from Tasks:
  - `openProductsForTask(taskId, scope)` switches to the `products` tab with pre-set `mode=byTask`, `taskId`, `scope`, `page=1`.

## Why
- Reduce complexity of `App.js` and improve readability/maintainability.
- Clear separation of concerns:
  - `App`: tab state + top-level actions.
  - Each page: owns its data fetching and UI logic.
- Better reuse (Pagination, ProductCard, Filters) and easier testing.

## URL behavior
- **Dashboard / Scraping / Tasks**: URL is **only** `?tab=<name>`.
- **Products**: URL includes the full set of product params (filters/sort/pagination).
- Navigating away from `products` preserves filters in memory and restores them (and the URL) when coming back.
- Direct deep links to `products` with query params initialize the page correctly.

## QA checklist
1. Open **Tasks** → click “open products” for a task:
   - Should navigate to **Products**, load items, and show `mode=byTask&taskId=...&scope=...` in the URL.
2. On **Products**, change filters/sort/page:
   - Leave the tab and come back: state is restored and URL reflects the last state.
3. Manually edit URL params on **Products** and reload:
   - The page should initialize from the URL.
4. Switch between `all` and `byTask`:
   - Filters/characteristics refresh accordingly; pagination resets to page 1.
5. Delete a product from the grid:
   - The grid reloads and totals update.

## Notes / Risks
- Product filters persist **in-memory** between tabs via `lastProductsQuery`. A full page reload without product params will reset to defaults (expected).
- Ensure all imports are updated after file moves.
- Network calls:
  - `GET /products`, `GET /tasks/{id}/products`, `GET /products/characteristics`, `GET /tasks/{id}/products/characteristics`, `DELETE /products/{id}`.
- The modal overlay was adjusted to use fixed, full-viewport layout with proper stacking context.

## How to migrate
1. Move new components into `components/*Page.jsx` files.
2. Update imports in `App.js` to use the new pages.
3. Remove legacy inlined pagination/card/filter code from `App.js`.
4. Verify environment variable `REACT_APP_BACKEND_URL` and endpoints.

Ready for review.
